### PR TITLE
Wrong file name for README in gem build script

### DIFF
--- a/git-rank.gemspec
+++ b/git-rank.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.description = "Use to rank contributors to a git project by lines of conribution"
   s.email = 'mattr@mattrobinson.net'
   s.executables = ['git-rank']
-  s.extra_rdoc_files = ['README']
+  s.extra_rdoc_files = ['README.md']
   s.files = `git ls-files`.split("\n")
   s.homepage = 'http://github.com/mmrobins/git-rank'
   s.rdoc_options = ['--charset=UTF-8']


### PR DESCRIPTION
Hi Matt,

i think the README file must have the suffix **.md**.

Greetings
Tim 
